### PR TITLE
Fixing get flavor details response JSON.

### DIFF
--- a/src/wadl/samples/cdn-getFlavorDetails_response.json
+++ b/src/wadl/samples/cdn-getFlavorDetails_response.json
@@ -1,20 +1,5 @@
-
+{
     "id": "cdn",
-    "limits": [
-        "origins": {
-            "min": 1,
-            "max": 5
-        },
-        "domains": {
-            "min": 1,
-            "max": 5
-        },
-        "caching": {
-            "min": 3600,
-            "max": 604800,
-            "incr": 300
-        }
-    ],
     "providers": [
         {
             "provider": "akamai",


### PR DESCRIPTION
I've added the missing `{` at the very beginning. I've also removed the `limits` property entirely as I don't see [the code](https://github.com/stackforge/poppy/blob/master/poppy/transport/pecan/models/response/flavor.py#L26-L46) generating this property in the JSON. I also verified this by making a live API call and confirming that the `limits` property is absent in the response.

Fixes #13
