### PR TITLE
Removing Content-Type and Accept headers

### DIFF
--- a/src/wadl/samples/cdn-deleteCachedAsset_request-json-http.txt
+++ b/src/wadl/samples/cdn-deleteCachedAsset_request-json-http.txt
@@ -1,5 +1,3 @@
 DELETE /v1.0/110011/services/serviceName/assets?urlOfAssetToCheck HTTP/1.1
 Host: global.cdn.api.rackspacecloud.com
 X-Auth-Token: 0f6e9f63600142f0a970911583522217
-Accept: application/json
-Content-type: application/json

--- a/src/wadl/samples/cdn-getPing_request-json-http.txt
+++ b/src/wadl/samples/cdn-getPing_request-json-http.txt
@@ -1,5 +1,4 @@
 GET /v1.0/110011/ping HTTP/1.1
 Host: global.cdn.api.rackspacecloud.com
 X-Auth-Token: 0f6e9f63600142f0a970911583522217
-Accept: application/json
-Content-type: application/json
+


### PR DESCRIPTION
The `Content-Type` request header is unnecessary because these requests have no representations (bodies) to them.

The `Accept` request header is unnecessary because the responses to these requests are not expected to have any representations (bodies) to them. In fact, supplying a strict `Accept` header like `Accept: application/json` has empirically shown to cause a `406 Not Acceptable` response.
