### PR TITLE
Adding information about multi-factor auth

### DIFF
--- a/src/docbkx/cdn-adminguide.xml
+++ b/src/docbkx/cdn-adminguide.xml
@@ -322,9 +322,23 @@
           <code>POST/v2.0/tokens</code> request, presenting valid Rackspace customer credentials in
         the message body to a Rackspace authentication endpoint. </para>
       <note xmlns:m="http://www.w3.org/1998/Math/MathML"
-        xmlns:wadl="http://wadl.dev.java.net/2009/02">
-        <para>If you cannot access the Rackspace CDN API, send an email to the Rackspace CDN team at
-            <email>cdn@rackspace.com</email> to request access. </para>
+        xmlns:wadl="http://wadl.dev.java.net/2009/02"><title>Notes</title>
+        <itemizedlist>
+          <listitem>
+            <para>If you cannot access the Rackspace CDN API, send an email to the Rackspace CDN team at
+              <email>cdn@rackspace.com</email> to request access. </para>
+          </listitem>
+          <listitem>
+            <para>
+              If you authenticate with username and password credentials, you can set up multi-factor authentication 
+              to add an additional level of security to your account. This feature is not available for username and 
+              API credentials. For information about setting up and 
+              authenticating with multi-factor authentication, see 
+              <link xlink:href="http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/MFA_Ops.html">Multifactor authentication</link> 
+              in the <citetitle>Cloud Identity Client Developer Guide</citetitle>.
+            </para>
+          </listitem>
+        </itemizedlist>
       </note>
       <para xmlns:m="http://www.w3.org/1998/Math/MathML"
         xmlns:wadl="http://wadl.dev.java.net/2009/02">
@@ -344,7 +358,7 @@
       <para xmlns:m="http://www.w3.org/1998/Math/MathML"
         xmlns:wadl="http://wadl.dev.java.net/2009/02">Your user name and password are the ones that
         you use to log in to the Rackspace Cloud Control Panel. After you are logged in, you can use
-        the Rackspace Cloud Control Panel to obtain your API key. </para>
+        the Rackspace Cloud Control Panel to obtain your API key.</para>
       <para xmlns:m="http://www.w3.org/1998/Math/MathML"
         xmlns:wadl="http://wadl.dev.java.net/2009/02"> US and UK based accounts use the Cloud
         Control Panel at <link xlink:href="https://mycloud.rackspacecloud.com/"
@@ -394,11 +408,45 @@
               <literallayout class="monospaced">curl -X POST https://auth.api.rackspacecloud.com/v2.0/tokens -d
 '{"auth":{"passwordCredentials":{"username":"yourUserName","password":"yourPassword"}}}' -H "Content-type: application/json"</literallayout>
             </example>
-            <para>Successful authentication returns a token that you can use as evidence that your
-              identity has already been authenticated. To use the token, pass it to other services
-              as an <code>X-Auth-Token</code> header. </para>
-            <para>Authentication also returns a service catalog, which lists the endpoints that you
-              can use for Rackspace Cloud services. </para>
+          </listitem>
+          <listitem>
+            <para>Review the authentication response.
+              <itemizedlist>
+                <listitem>
+                <para>Successful authentication returns a token that you can use as evidence that your
+                  identity has already been authenticated along with a service catalog, which lists the
+                  endpoints that you can use for Rackspace Cloud services. To use the token, pass it to
+                  other services as an <code>X-Auth-Token</code> header.</para>
+                </listitem>
+                <listitem>
+                  <para>If the Identity service returns a returns a 401 message with a request for
+                    additional credentials, your account requires <link
+                      xlink:href="http://docs-internal.rackspace.com/auth/api/v2.0/auth-admin-devguide/content/MFA_Ops.htmlmulti-factor authentication"
+                      >multi-factor authentication</link>. To complete the authentication process,
+                    submit a second <guilabel>POST tokens</guilabel> request with these multi-factor
+                    authentication credentials: <itemizedlist>
+                      <listitem>
+                        <para>The session ID value returned in the <code>WWW-Authenticate: OS-MF
+                            sessionId</code> header parameter that is included in the response to
+                          the initial authentication request.</para>
+                      </listitem>
+                      <listitem>
+                        <para>The passcode from the mobile phone associated with your user
+                          account.</para>
+                        <example>
+                          <title>Authentication request with multi-factor authentication
+                            credentials</title>
+                          <programlisting language="bash" role="gutter: false"><?db-font-size 60%?><prompt>$</prompt>curl https://identity.api.rackspacecloud.com/v2.0/tokens \
+     -X POST \
+     -d '{"auth": {"RAX-AUTH:passcodeCredentials": {"passcode":"1411594"}}}'\
+     -H "X-SessionId: $SESSION_ID" \
+     -H "Content-Type: application/json" --verbose | python -m json.tool</programlisting>
+                        </example>
+                      </listitem>
+                    </itemizedlist></para>
+                </listitem>
+              </itemizedlist>
+            </para>
           </listitem>
           <listitem>
             <para>Use the authentication token to send a <command>GET</command> request to a service

--- a/src/docbkx/cdn-devguide.xml
+++ b/src/docbkx/cdn-devguide.xml
@@ -313,7 +313,7 @@
         Identity service and supplying a valid username and API access key. </para>
       <section xml:id="Geographic_Endpoints" xmlns:m="http://www.w3.org/1998/Math/MathML">
         <title>Geographic endpoints</title>
-        <para> The Rackspace Cloud Identity service serves as the entry point to all Rackspace Cloud
+        <para>The Rackspace Cloud Identity service serves as the entry point to all Rackspace Cloud
           APIs and is itself a RESTful web service. </para>
         <para> You can use either of the following endpoints to access the Rackspace Cloud Identity
           service for authentication:</para>
@@ -355,9 +355,22 @@
           for <code>username</code> and <code>apiKey</code>. When you authenticate successfully, the
           response to your authentication request will include a catalog of the services to which
           you have subscribed rather than the example values shown here.</para>
-        <note>
-          <para>For more information about how to use cURL to retrieve the authentication token, see
-            the <citetitle>Rackspace CDN Getting Started Guide</citetitle>.</para>
+        <note><title>Notes</title>
+          <itemizedlist>
+            <listitem>
+              <para>For more information about how to use cURL to retrieve the authentication token, see
+                the <citetitle>Rackspace CDN Getting Started Guide</citetitle>.</para>
+            </listitem>
+            <listitem>
+              <para>
+                If you authenticate with username and password credentials, you can set up multi-factor authentication 
+                to add an additional level of security to your account. This feature is not available for username and 
+                API credentials. For information about setting up and using multi-factor authentication, see 
+                <link xlink:href="http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/MFA_Ops.html">Multifactor authentication</link> 
+                in the <citetitle>Cloud Identity Client Developer Guide</citetitle>.
+              </para>
+            </listitem>
+          </itemizedlist>
         </note>
         <example>
           <title>Authentication with US endpoint: XML request</title>


### PR DESCRIPTION
* Updated the Admin and Dev Guide with a note about
   availability of multi-factor authentication to protect
   username and passcode credentials.

* In the Dev Guide, added the cURL command to submit
   multi-factor authentication credentials if the Identity
   Services returns a 401 message requesting additional
   credentials.

In the Getting Started Guide, the authentication procedure describes how to 
authenticate with username + API credentials. Because you cannot apply multi-factor authentication to 
these credentials, I didn't add multi-factor authentication information to this section.  You might consider adding a note along these lines:   For information about other supported authentication methods, see the 
.. _Cloud Identity Client Developer Guide: http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/Token_Calls.html .