### PR TITLE
Add rate limit for purge cached assets endpoint for 4/14/2016 deployment

### DIFF
--- a/api-docs/api-operations/methods/delete-purge-a-cached-asset-v1.0-project-id-services-service-id-assets.rst
+++ b/api-docs/api-operations/methods/delete-purge-a-cached-asset-v1.0-project-id-services-service-id-assets.rst
@@ -10,6 +10,10 @@ Purge a cached asset
 
 This operation purges a cached asset or invalidates the cache.
 
+.. note::
+   The rate limit for this operation is 20 requests per minute. 
+
+
 When you specify a purge, this operation purges the current version of the asset that has been cached at the edge node. Currently in Rackspace CDN, purges require the URL of the file to purge. Use of wildcards is not in effect.
 
 .. note::

--- a/api-docs/general-api-info/absolute-limits.rst
+++ b/api-docs/general-api-info/absolute-limits.rst
@@ -8,25 +8,30 @@ Rackspace CDN API.
 
 **Table: Absolute limits**
 
-+-----------------------+------------------------------+----------------------+
-| Name                  | Description                  | Limit                |
-+=======================+==============================+======================+
-| Client maximum body   | Maximum size of request body.| 8 KB                 |
-| size restriction      | Exceeding the limit results  |                      |
-|                       | in a 413 (Request Entity Too |                      |
-|                       | Large) error.                |                      |
-+-----------------------+------------------------------+----------------------+
-| Maximum for the entire| Maximum size of request URI. | 320 characters       |
-| length for a domain   | Exceeding the limit results  |                      |
-| URI                   | in a 414 (URI Too Long)      |                      | 
-|                       | error.                       |                      |
-+-----------------------+------------------------------+----------------------+
-| TTL when creating     | Maximum TTL value.           | 365 days             |
-| a service             |                              |                      |
-+-----------------------+------------------------------+----------------------+
-| Limit on the number   | Maximum number of domains    | 20 domains           |
-| of domains that can   | that can be listed.          |                      |
-| be listed when        |                              |                      |
-| retrieving all        |                              |                      |
-| services              |                              |                      |
-+-----------------------+------------------------------+----------------------+
++----------------------------+------------------------------+----------------------+
+| Name                       | Description                  | Limit                |
++============================+==============================+======================+
+| Client maximum body        | Maximum size of request body.| 8 KB                 |
+| size restriction           | Exceeding the limit results  |                      |
+|                            | in a 413 (Request Entity Too |                      |
+|                            | Large) error.                |                      |
++----------------------------+------------------------------+----------------------+
+| Maximum for the entire     | Maximum size of request URI. | 320 characters       |
+| length for a domain        | Exceeding the limit results  |                      |
+| URI                        | in a 414 (URI Too Long)      |                      | 
+|                            | error.                       |                      |
++----------------------------+------------------------------+----------------------+
+| TTL when creating          | Maximum TTL value.           | 365 days             |
+| a service                  |                              |                      |
++----------------------------+------------------------------+----------------------+
+| Limit on the number        | Maximum number of domains    | 20 domains           |
+| of domains that can        | that can be listed.          |                      |
+| be listed when             |                              |                      |
+| retrieving all             |                              |                      |
+| services                   |                              |                      |
++----------------------------+------------------------------+----------------------+
+| Rate limit on the          | Number of requests per       | 20 requests per      |
+| :ref:`Purge a cached       | minute.                      | minute               |
+| asset operation            |                              |                      |
+| <cdn-purge-a-cached-asset>`|                              |                      |
++----------------------------+------------------------------+----------------------+

--- a/api-docs/release-notes.rst
+++ b/api-docs/release-notes.rst
@@ -12,6 +12,7 @@ details about |apiservice| |contract version| service updates.
 .. toctree::
    :maxdepth: 2  
       
+   April 14, 2016 <release-notes/cdn-v1-20160414>
    March 7, 2016 <release-notes/cdn-v1-20160307>
    January 20, 2016 <release-notes/cdn-v1-20160120>
    January 13, 2016 <release-notes/cdn-v1-20160113>

--- a/api-docs/release-notes/cdn-v1-20160414.rst
+++ b/api-docs/release-notes/cdn-v1-20160414.rst
@@ -1,0 +1,17 @@
+API |contract version| updates, April 14, 2016
+---------------------------------------------------
+
+What's new
+~~~~~~~~~~
+
+Added a rate limit of 20 requests per minute to the :ref:`Purge a cached asset operation <cdn-purge-a-cached-asset>`.
+
+Resolved issues
+~~~~~~~~~~~~~~~
+
+|no changes|
+
+Known issues
+~~~~~~~~~~~~
+
+|no changes|


### PR DESCRIPTION
Add rate limit of 20 requests per minute to the purge a cached asset endpoints. Additions were made to the following files:

- Absolute limits - adds rate limit to table

- purge a cached assets method file - adds note with rate limit info

- adds a new release note file for 4/14/2016 deployment

- updates releasenotes.rst to add a link to the new release notes file for 4/14/2016